### PR TITLE
Fix typos

### DIFF
--- a/LemonGraph/callableiterable.py
+++ b/LemonGraph/callableiterable.py
@@ -1,4 +1,4 @@
-# decorator shennanigans to bless class methods such that they can be referenced
+# decorator shenanigans to bless class methods such that they can be referenced
 # as an iterable property or called with parameters (also returns an iterable)
 class CallableIterable(object):
     def __init__(self, func, target):

--- a/LemonGraph/cffi_stubs.py
+++ b/LemonGraph/cffi_stubs.py
@@ -154,7 +154,7 @@ size_t graph_edges_count(graph_txn_t txn, logID_t beforeID);
 // delete any type of graph entity
 logID_t graph_delete(graph_txn_t txn, entry_t e);
 
-// iterator foo - be sure to close them before aborting or commiting a txn
+// iterator foo - be sure to close them before aborting or committing a txn
 graph_iter_t graph_nodes(graph_txn_t txn, logID_t beforeID);
 graph_iter_t graph_edges(graph_txn_t txn, logID_t beforeID);
 graph_iter_t graph_nodes_type(graph_txn_t txn, void *type, size_t tlen, logID_t beforeID);

--- a/LemonGraph/dbtool.py
+++ b/LemonGraph/dbtool.py
@@ -16,7 +16,7 @@ To set ad-hoc query mode (default), simply enter: 0
 To set streaming query mode, enter a numeric start,stop tuple or a non-zero start.
 
 To query, enter one or more query patterns, joined by semi-colons.
-To force streaming or ad-hoc mode, the line may be preceeded by:
+To force streaming or ad-hoc mode, the line may be preceded by:
 	start,stop:
 or just:
 	start:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Using PyPy 4.0 on physical hardware (3ghz X5670, plenty of RAM), under a single 
 
 # Features
 
-Symas LMDB provides transactions, multi-process MVCC abilities (single writer, multple non-blocking readers), nested write transactions, and rapid non-blocking binary snapshots. We also inherit some caveats:
+Symas LMDB provides transactions, multi-process MVCC abilities (single writer, multiple non-blocking readers), nested write transactions, and rapid non-blocking binary snapshots. We also inherit some caveats:
 
 * max database mapsize has to be manually maintained, but on 64-bit platforms it is cheap to overestimate
 * transactions should only be used from the thread that created them


### PR DESCRIPTION
I noticed a single typo in `README.md` as I was reading about this project. After the original commit, I found a few more typos. This PR fixes them. I guess I should have named my branch `fix_typos` after all!
