### PR TITLE
Fix `QuerySyntaxError.__repr__`

### DIFF
--- a/LemonGraph/MatchLGQL.py
+++ b/LemonGraph/MatchLGQL.py
@@ -198,7 +198,9 @@ class QuerySyntaxError(Exception):
         return 'Query syntax error - %s at index %d: %s' % (self.message, self.pos, self.query)
 
     def __repr__(self):
-        return 'QuerySyntaxError(%s, %s, %s)' % map(repr, (self.query, self.pos, self.message))
+        return 'QuerySyntaxError(%s, %s, %s)' % tuple(
+            repr(arg) for arg in (self.query, self.pos, self.message))
+
 
 class MatchLGQL(object):
     def __init__(self, filter, cache=None):


### PR DESCRIPTION
The `__repr__` method in `QuerySyntaxError` raises a `TypeError`.

```python
# LemonGraph.MatchLGQL
class QuerySyntaxError(Exception):
    ...
    def __repr__(self):
        return 'QuerySyntaxError(%s, %s, %s)' % map(repr, (self.query, self.pos, self.message))
                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

```python
In[38]: 'QuerySyntaxError(%s, %s, %s)' % map(repr, ('query', 1, 'message'))
Traceback (most recent call last):
    'QuerySyntaxError(%s, %s, %s)' % map(repr, ('query', 1, 'message'))
TypeError: not enough arguments for format string

# Python 2 `map` returns a list
In[39]: map(repr, ('query', 1, 'message'))
Out[39]: 
["'query'", '1', "'message'"]

In[40]: 'QuerySyntaxError(%s, %s, %s)' % ["'query'", '1', "'message'"]
Traceback (most recent call last):
    'QuerySyntaxError(%s, %s, %s)' % ["'query'", '1', "'message'"]
TypeError: not enough arguments for format string

# Tuple, not list, is needed
In[41]: 'QuerySyntaxError(%s, %s, %s)' % ("'query'", '1', "'message'")
Out[41]: 
"QuerySyntaxError('query', 1, 'message')"

# This works, but `map` creates an unnecessary list
In[42]: 'QuerySyntaxError(%s, %s, %s)' % tuple(map(repr, ('query', 1, 'message')))
Out[42]: 
"QuerySyntaxError('query', 1, 'message')"

# Using a tuple comprehension doesn't create that extra list
In[43]: 'QuerySyntaxError(%s, %s, %s)' % tuple(repr(arg) for arg in ('query', 1, 'message'))
Out[43]: 
"QuerySyntaxError('query', 1, 'message')"
```
