### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/LemonGraph/MatchLGQL.py
+++ b/LemonGraph/MatchLGQL.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import re
 import sys
 import itertools
@@ -571,17 +572,17 @@ class MatchLGQL(object):
                 yield seed
 
     def dump(self, fh=sys.stdout):
-        print >>fh, '['
+        print('[', file=fh)
         for p in self.matches:
             pre = dict( (key, val) for key, val in p.iteritems() if key != 'tests' )
             if p['tests']:
-                print >>fh, '\t%s:[' % pre
+                print('\t%s:[' % pre, file=fh)
                 for test in p['tests']:
-                    print >>fh, "\t\t", test, ","
-                print >>fh, "\t],"
+                    print("\t\t", test, ",", file=fh)
+                print("\t],", file=fh)
             else:
-                print >>fh, '\t%s:[],' % pre
-        print >>fh, ']'
+                print('\t%s:[],' % pre, file=fh)
+        print(']', file=fh)
 
     def is_valid(self, obj, idx=0, skip_fudged=False):
         match = self.matches[idx]

--- a/LemonGraph/__init__.py
+++ b/LemonGraph/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 try:
     from ._lemongraph_cffi import ffi, lib
 except ImportError:
@@ -67,7 +68,7 @@ def merge_values(a, b):
 class Graph(object):
     serializers = tuple('serialize_' + x for x in ('node_type', 'node_value', 'edge_type', 'edge_value', 'property_key', 'property_value'))
 
-    def __init__(self, path, flags=0, mode=0760, nosubdir=True, noreadahead=False, notls=False, nosync=False, nometasync=False, readonly=False, create=True, excl=False, hooks=Hooks(), adapters=None, **kwargs):
+    def __init__(self, path, flags=0, mode=0o760, nosubdir=True, noreadahead=False, notls=False, nosync=False, nometasync=False, readonly=False, create=True, excl=False, hooks=Hooks(), adapters=None, **kwargs):
         self._graph = None
         for func in self.serializers:
             setattr(self, func, kwargs.pop(func, None) or self.default_serializer)
@@ -492,13 +493,13 @@ class Transaction(GraphItem):
         """pretty printer"""
         out = kwargs.pop('out', sys.stdout)
         for obj in self.scan(**kwargs):
-            print >>out, obj.pretty()
+            print(obj.pretty(), file=out)
 
     def dump(self, **kwargs):
         """not-so-pretty printer"""
         out = kwargs.pop('out', sys.stdout)
         for obj in self.scan(**kwargs):
-            print >>out, obj.dump()
+            print(obj.dump(), file=out)
 
     def kv(self, domain, map_data=False, map_keys=False, serialize_key=None, serialize_value=None):
         """domain-specific key/value storage"""
@@ -1033,7 +1034,7 @@ class Adapters(object):
                 gen = gen()
 
             try:
-                pattern = gen.next()
+                pattern = next(gen)
             except StopIteration:
                 raise Exception("generator failed to return pattern (or None)")
 

--- a/LemonGraph/collection.py
+++ b/LemonGraph/collection.py
@@ -22,7 +22,7 @@ def uuidgen():
     return str(uuid.uuid1())
 
 def uuid_to_utc_ts(u):
-    return (uuid.UUID('{%s}' % u).get_time() - 0x01b21dd213814000L) / 1e7
+    return (uuid.UUID('{%s}' % u).get_time() - 0x01b21dd213814000) / 1e7
 
 def uuid_to_utc(u):
     return datetime.datetime.utcfromtimestamp(uuid_to_utc_ts(u)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
@@ -448,7 +448,7 @@ class Collection(object):
         map_age = 0
         log.info('using %d max open graphs' % maxopen)
         while True:
-            ticker.next()
+            next(ticker)
             sleep(poll)
             map_age += poll
             if map_age >= 60:

--- a/LemonGraph/dbtool.py
+++ b/LemonGraph/dbtool.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from . import Graph, Serializer, QuerySyntaxError
 
 import msgpack
@@ -54,21 +55,21 @@ def do_query(txn, query, start=0, stop=0, interactive=False):
             mode = 'dump'
             total = None
         elif 'g' == query:
-            print dict( (k, v) for k,v in txn.iteritems() )
+            print(dict( (k, v) for k,v in txn.iteritems() ))
             mode = 'graph properties'
             total = None
         elif len(queries) > 1:
-            print queries
+            print(queries)
             for q, chain in txn.mquery(queries, cache=cache, start=start, stop=stop):
-                print q, chain
+                print(q, chain)
                 total += 1
         else:
             for chain in txn.query(query, cache=cache, start=start, stop=stop):
-                print chain
+                print(chain)
                 total += 1
     except KeyboardInterrupt:
         if interactive:
-            print >>sys.stderr, "<cancelled>"
+            print("<cancelled>", file=sys.stderr)
         else:
             raise
     tstop = time.time()
@@ -106,19 +107,19 @@ def main(g):
                 m = RANGE1.match(line)
                 if m:
                     start, stop = parse_range(m)
-                    print "streaming %s" % ('enabled' if start else 'disabled')
+                    print("streaming %s" % ('enabled' if start else 'disabled'))
                     prompt = None
                     line = None
 
                 elif line in ('help','?'):
-                    print HELP
+                    print(HELP)
                     line = None
 
                 elif 'r' == line:
                     line = prompt = None
                 elif 'history' == line:
                     for i in xrange(1, readline.get_current_history_length()):
-                        print readline.get_history_item(i)
+                        print(readline.get_history_item(i))
                     line = None
 
                 if line or prompt is None:
@@ -127,14 +128,14 @@ def main(g):
                             try:
                                 total, delta, mode = do_query(txn, line, start=start, stop=stop if stop else lastID, interactive=True)
                             except QuerySyntaxError as e:
-                                print >>sys.stderr, str(e)
+                                print(str(e), file=sys.stderr)
                                 total = None
                                 mode = 'error'
                                 delta = 0
                             if total is None:
-                                print "\n%s (%f seconds)\n" % (mode, delta)
+                                print("\n%s (%f seconds)\n" % (mode, delta))
                             else:
-                                print "\n%d chains (%f seconds, %s)\n" % (total, delta, mode)
+                                print("\n%d chains (%f seconds, %s)\n" % (total, delta, mode))
                         if lastID != txn.lastID:
                             lastID = txn.lastID
                             prompt = None

--- a/LemonGraph/httpd.py
+++ b/LemonGraph/httpd.py
@@ -168,7 +168,7 @@ class Chunks(object):
     def chunkify(self, gen):
         bs = self.bs
         chunks = self.chunks()
-        chunk = chunks.next()
+        chunk = next(chunks)
 
         pos = 0
         for src in gen:
@@ -185,14 +185,14 @@ class Chunks(object):
                 # pad buffer out to end using first n bytes from src
                 chunk.payload[pos:bs] = src[0:soff]
                 yield chunk
-                chunk = chunks.next()
+                chunk = next(chunks)
                 pos = 0
 
                 # then carve off full blocks directly from src
                 while soff + bs <= slen:
                     chunk.payload[0:bs] = src[soff:soff+bs]
                     yield chunk
-                    chunk = chunks.next()
+                    chunk = next(chunks)
                     soff += bs
 
                 # and stash the remainder
@@ -732,7 +732,7 @@ class Headers(object):
         return self.norm(header) in self.data
 
     def __setitem__(self, header, value):
-        if isinstance(value, types.StringTypes):
+        if isinstance(value, (str,)):
             self.data[self.norm(header)] = Header(header, value)
         else:
             self.data[self.norm(header)] = Header(header, *value)

--- a/LemonGraph/query.py
+++ b/LemonGraph/query.py
@@ -1,3 +1,4 @@
+import itertools
 from collections import deque, defaultdict
 
 from . import Node, Edge

--- a/LemonGraph/server.py
+++ b/LemonGraph/server.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from . import Serializer, Node, Edge, Adapters, QuerySyntaxError, merge_values
 from .collection import Collection, uuid_to_utc
 from .lock import Lock
@@ -85,7 +86,7 @@ class SeedTracker(object):
     def seeds(self):
         try:
             gen = self._seed.itervalues()
-            gen.next()
+            next(gen)
         except (KeyError, StopIteration):
             return ()
         return gen
@@ -410,7 +411,7 @@ class _Streamy(object):
     def _stream_js(self, gen):
         yield '['
         try:
-            x = gen.next()
+            x = next(gen)
             yield x
             for x in gen:
                 yield ','
@@ -430,7 +431,7 @@ class _Streamy(object):
         yield self.dumps(dict(txn.iteritems()))
         yield ',"nodes":['
         try:
-            n = nodes.next()
+            n = next(nodes)
             yield self.dumps(n.as_dict())
             for n in nodes:
                 yield ','
@@ -439,7 +440,7 @@ class _Streamy(object):
             pass
         yield '],"edges":['
         try:
-            e = edges.next()
+            e = next(edges)
             yield self.dumps(self.format_edge(e))
             for e in edges:
                 yield ','
@@ -766,7 +767,7 @@ class D3_UUID(_Streamy, Handler):
         nidx = 0
         nodes = txn.nodes()
         try:
-            n = nodes.next()
+            n = next(nodes)
             nmap[n.ID] = nidx
             nidx += 1
             yield self.dumps({ 'data': n.as_dict() })
@@ -780,7 +781,7 @@ class D3_UUID(_Streamy, Handler):
         yield '],"edges":['
         edges = txn.edges()
         try:
-            e = edges.next()
+            e = next(edges)
             yield self.dumps({
                 'data': e.as_dict(),
                 'source': nmap[e.srcID],
@@ -814,7 +815,7 @@ class Graph_Exec(_Input, _Streamy):
 
         txns_uuids = self._txns_uuids(uuids)
         try:
-            exec code in globals, locals
+            exec(code, globals, locals)
             params = dict((k, v) if len(v) > 1 else (k, v[0]) for k, v in self.params.iteritems() if k not in eat_params)
             try:
                 handler = locals['handler']
@@ -850,7 +851,7 @@ class Graph_UUID_Exec(_Input, _Streamy):
             'HTTPError': HTTPError,
         }
         try:
-            exec code in globals, locals
+            exec(code, globals, locals)
             params = dict((k, v) if len(v) > 1 else (k, v[0]) for k, v in self.params.iteritems())
             try:
                 handler = locals['handler']
@@ -1102,23 +1103,23 @@ def update_depth_cost():
                     apply_cost(txn, entry)
 
 def usage(msg=None, fh=sys.stderr):
-    print >>fh, 'Usage: python -mLemonGraph.server <options> [graphs-dir]'
-    print >>fh, ''
-    print >>fh, 'Options:'
-    print >>fh, '  -i <bind-ip>        (127.0.0.1)'
-    print >>fh, '  -p <bind-port>      (8000)'
-    print >>fh, '  -d <poll-delay-ms>  (250)'
-    print >>fh, '  -w <workers>        (#cpu cores)'
-    print >>fh, '  -l <log-level>      (info)'
-    print >>fh, '  -t <timeout>        (3 seconds)'
-    print >>fh, '  -b <buflen>         (1048576)'
-    print >>fh, '  -s                  enable nosync for graph dbs'
-    print >>fh, '  -m                  enable nometasync for graph dbs'
-    print >>fh, '  -r                  rebuild index'
-    print >>fh, '  -h                  print this help and exit'
+    print('Usage: python -mLemonGraph.server <options> [graphs-dir]', file=fh)
+    print('', file=fh)
+    print('Options:', file=fh)
+    print('  -i <bind-ip>        (127.0.0.1)', file=fh)
+    print('  -p <bind-port>      (8000)', file=fh)
+    print('  -d <poll-delay-ms>  (250)', file=fh)
+    print('  -w <workers>        (#cpu cores)', file=fh)
+    print('  -l <log-level>      (info)', file=fh)
+    print('  -t <timeout>        (3 seconds)', file=fh)
+    print('  -b <buflen>         (1048576)', file=fh)
+    print('  -s                  enable nosync for graph dbs', file=fh)
+    print('  -m                  enable nometasync for graph dbs', file=fh)
+    print('  -r                  rebuild index', file=fh)
+    print('  -h                  print this help and exit', file=fh)
     if msg is not None:
-        print >>fh, ''
-        print >>fh, msg
+        print('', file=fh)
+        print(msg, file=fh)
     sys.exit(1)
 
 def main():

--- a/LemonGraph/snapshot.py
+++ b/LemonGraph/snapshot.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 
 from . import Graph
@@ -5,7 +6,7 @@ from . import Graph
 try:
     db = sys.argv[1]
 except:
-    print >>sys.stderr, "Usage: python -mLemonGraph.snapshot path/to/src.db > dst.db"
+    print("Usage: python -mLemonGraph.snapshot path/to/src.db > dst.db", file=sys.stderr)
     sys.exit(1)
 
 with Graph(db, create=False) as g:

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import platform
 import stat
@@ -29,10 +30,10 @@ def git_submodule_init():
 
 
 def do_curl(url):
-    print >> sys.stderr, "Fetching: %s" % url
+    print("Fetching: %s" % url, file=sys.stderr)
     cmd = ('curl', '-L', url)
     p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE)
-    print >> sys.stderr, url
+    print(url, file=sys.stderr)
     blen = 0
     for chunk in p.stdout:
         blen += len(chunk)
@@ -72,14 +73,14 @@ def fetch_js():
         try:
             s2 = os.stat(target)
         except OSError:
-            print >> sys.stderr, "Hard linking: %s -> %s" % (source, target)
+            print("Hard linking: %s -> %s" % (source, target), file=sys.stderr)
             os.link(source, target)
             continue
 
         for i in (stat.ST_INO, stat.ST_DEV):
             if s1[i] != s2[i]:
                 os.unlink(target)
-                print >> sys.stderr, "Hard linking: %s -> %s" % (source, target)
+                print("Hard linking: %s -> %s" % (source, target), file=sys.stderr)
                 os.link(source, target)
                 break
 


### PR DESCRIPTION
Partial fix to #12 

Minimal, safe changes required to make this code syntax compatible with both Python 2 and Python 3.  There will probably be more changes required to complete the port to Python 3 but this should provide a solid start in that process without breaking backward compatibility with legacy Python.