### PR TITLE
Define xrange() in Python 3

### DIFF
--- a/LemonGraph/collection.py
+++ b/LemonGraph/collection.py
@@ -15,6 +15,11 @@ from pysigset import suspended_signals
 
 from . import Graph, Serializer, Transaction, Hooks, dirlist, Indexer, Query
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 

--- a/LemonGraph/serializer.py
+++ b/LemonGraph/serializer.py
@@ -2,6 +2,12 @@ from . import ffi, lib
 import msgpack as messagepack
 import collections
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
+
 def msgpack_encode_hashable(x):
     if not isinstance(x, collections.Hashable):
         raise ValueError(x)


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of __range()__.  This PR ensures similar functionality in both Python 2 and Python 3.