### PR TITLE
Define raw_input() for Python 3

### DIFF
--- a/LemonGraph/dbtool.py
+++ b/LemonGraph/dbtool.py
@@ -9,9 +9,14 @@ import sys
 import time
 
 try:
-    xrange          # Python 2
+    raw_input          # Python 2
 except NameError:
-    xrange = range  # Python 3
+    raw_input = input  # Python 3
+
+try:
+    xrange             # Python 2
+except NameError:
+    xrange = range     # Python 3
 
 s = Serializer.msgpack()
 cache = {}


### PR DESCRIPTION
__raw_input()__ was removed in Python 3 in favor of __input()__.  This PR ensures equivalent functionality in both Python 2 and Python 3.