### PR TITLE
from ..httpd import Graceful in __main__.py

### DIFF
--- a/LemonGraph/server/__main__.py
+++ b/LemonGraph/server/__main__.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from .. import Serializer, Adapters
 from ..collection import Collection
+from ..httpd import Graceful
 from . import Server
 
 import sys


### PR DESCRIPTION
__Graceful__ is used on line 180 but it is never imported.

flake8 testing of https://github.com/NationalSecurityAgency/lemongraph on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./LemonGraph/server/__main__.py:179:16: F821 undefined name 'Graceful'
        except Graceful:
               ^
```