### PR TITLE
Define buffer and unicode in Python 3

### DIFF
--- a/LemonGraph/httpd.py
+++ b/LemonGraph/httpd.py
@@ -30,6 +30,16 @@ except ImportError:
 from lazy import lazy
 from pysigset import suspended_signals
 
+try:
+    buffer               # Python 2
+except NameError:
+    buffer = memoryview  # Python 3
+
+try:
+    unicode              # Python 2
+except NameError:
+    unicode = str        # Python 3
+
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 


### PR DESCRIPTION
* __buffer__ was removed in Python 3 in favor of __memoryview__ which has a similar but not identical interface.
* __unicode__ was removed in Python 3 because all __str__ are Unicode.