### PR TITLE
minor code improvements

### DIFF
--- a/LemonGraph/MatchLGQL.py
+++ b/LemonGraph/MatchLGQL.py
@@ -6,8 +6,8 @@ import itertools
 
 from collections import defaultdict, deque
 
-SQ = '(?:\'(?:[^\'\\\\]|\\\\[\'\"\\\\])*\')'
-DQ = '(?:\"(?:[^\"\\\\]|\\\\[\'\"\\\\])*\")'
+SQ = r'''(?:'(?:[^'\\]|\\['"\\])*')'''
+DQ = r'''(?:"(?:[^"\\]|\\['"\\])*")'''
 BW = '(?:(?:(?![0-9])\w)\w*)'
 
 STR = re.compile('(?:%s|%s)' % (DQ, SQ), re.UNICODE)

--- a/LemonGraph/algorithms.py
+++ b/LemonGraph/algorithms.py
@@ -7,7 +7,7 @@ from collections import deque
 # else cost_field may be supplied to pull edge weight/cost from a named edge property, defaulting to cost_default
 # in all cases, the calculated edge weight/cost must be a non-negative number (floating point is fine)
 def shortest_path(source, target, directed=False, cost_field=None, cost_default=1, cost_cb=None):
-    if target.ID is source.ID:
+    if target.ID == source.ID:
         return 0, (source,)
 
     if cost_cb is None:


### PR DESCRIPTION
For integers outside the range -5..256, the same value may be a unique object, so comparison should be done by value equality (`==`) rather than identifier equality (`is`).