### PR TITLE
Fix Python 3 exception.message regressions in REST error paths

### DIFF
--- a/LemonGraph/MatchLGQL.py
+++ b/LemonGraph/MatchLGQL.py
@@ -346,7 +346,7 @@ class MatchLGQL(object):
             try:
                 lst.append(CLEAN_VAL[reg](m, m.group(0), self.cache))
             except ValueError as e:
-                raise self.syntax_error("bad value", pos=e.message)
+                raise self.syntax_error("bad value", pos=e.args[0])
             m, reg = self.token(COMMA, LIST_END)
             if reg is LIST_END:
                 return tuple(lst)
@@ -416,7 +416,7 @@ class MatchLGQL(object):
                 try:
                     val = (CLEAN_VAL[reg](m, m.group(0), self.cache),)
                 except ValueError as e:
-                    raise self.syntax_error("bad value", pos=e.message)
+                    raise self.syntax_error("bad value", pos=e.args[0])
             if '=' == op:
                 matches.appendleft((key, op, val))
             else:

--- a/LemonGraph/httpd.py
+++ b/LemonGraph/httpd.py
@@ -767,7 +767,7 @@ def zcat(gen):
         if len(final):
             yield final
     except zlib.error as e:
-        raise Disconnected('zlib error: ' + e.message)
+        raise Disconnected('zlib error: ' + str(e))
 
 
 class Step(HTTPMethods):

--- a/test.py
+++ b/test.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import unittest
 
-from LemonGraph import Graph, Serializer, dirlist, Query
+from LemonGraph import Graph, Serializer, dirlist, Query, QuerySyntaxError
 
 node = lambda i: dict((k, Nodes[i][k]) for k in ('type', 'value'))
 edge = lambda i: dict((k, Edges[i][k]) for k in ('type', 'value', 'src', 'tgt'))
@@ -391,6 +391,16 @@ class TestQL(unittest.TestCase):
                 except KeyError:
                     results[p] = [i]
         self.assertEqual(self.matches, results)
+
+    def test_bad_numeric_value(self):
+        # A token that matches the NUM regex but is not a real number (e.g. '+',
+        # '.', 'e') should surface as a clean QuerySyntaxError, not leak whatever
+        # the underlying float() conversion raised. Regression guard: these used
+        # to raise AttributeError on Python 3 because the handler read e.message.
+        from LemonGraph.MatchLGQL import MatchLGQL
+        for q in ('n(foo=+)', 'n(foo=.)', 'n(foo=e)', 'n(foo=[+])'):
+            with self.assertRaises(QuerySyntaxError):
+                MatchLGQL(q)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
While reading through the query and HTTP paths I hit a few leftover uses of `exception.message`. That attribute was removed in Python 3, so on Py3 these handlers raise `AttributeError` instead of the error they were written to raise, and the AttributeError then escapes to the caller.

Three spots:

- `MatchLGQL.parse_guts` and `parse_list`: a value that matches the NUM regex but is not actually a number (`+`, `.`, `e`, and so on) makes `_clean_num` raise `ValueError`. The handler tried to read `e.message` to build the position, which throws, so the query endpoint sees an AttributeError and returns 500 instead of the QuerySyntaxError -> 400 it means to. `ValueError(m.start())` already carries the position as `args[0]`, so `e.args[0]` is the direct fix and keeps working on Py2.
- `httpd.zcat`: a corrupt gzip request body raises `zlib.error`, and again the handler read `.message` before raising `Disconnected`. Switched to `str(e)`.

You can reach the first one over HTTP with something like `GET /graph/<uuid>?q=n(foo=%2B)` (the value is a bare `+`), and the gzip one by POSTing a bad body with `Content-Encoding: gzip`.

I added a small regression test under `TestQL` that feeds the malformed numeric values (scalar and list forms) and checks they come back as `QuerySyntaxError`. Before the change that test errors out with the AttributeError from `parse_guts`; after, it passes. This lines up with the earlier Python 3 cleanup work in the repo.